### PR TITLE
COVP-133 Spring boosters - metrics for APIv1 and APIv2

### DIFF
--- a/app/utils/assets.py
+++ b/app/utils/assets.py
@@ -149,9 +149,14 @@ class MetricData:
             "newPeopleVaccinatedAutumn22ByVaccinationDate",
             "cumPeopleVaccinatedAutumn22ByVaccinationDate",
             "cumVaccinationAutumn22UptakeByVaccinationDatePercentage",
+
             "newPeopleVaccinatedSpring22ByVaccinationDate",
             "cumPeopleVaccinatedSpring22ByVaccinationDate",
             "cumVaccinationSpring22UptakeByVaccinationDatePercentage",
+            
+            "newPeopleVaccinatedSpring23ByVaccinationDate",
+            "cumPeopleVaccinatedSpring23ByVaccinationDate",
+            "cumVaccinationSpring23UptakeByVaccinationDatePercentage",
         ]
     }
 

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -425,6 +425,12 @@ DATA_TYPES: Dict[str, Callable[[str], Any]] = {
     "cumVaccinationCompleteCoverageByVaccinationDatePercentage": float,
     "newPeopleVaccinatedCompleteByVaccinationDate": int,
 
+    "cumPeopleVaccinatedAutumn22ByVaccinationDate50plus": int,
+    "cumVaccinationAutumn22UptakeByVaccinationDatePercentage50plus": float,
+    "newPeopleVaccinatedSpring23ByVaccinationDate75plus": int,
+    "cumPeopleVaccinatedSpring23ByVaccinationDate75plus": int,
+    "cumVaccinationSpring23UptakeByVaccinationDatePercentage75plus": float,
+
     "vaccinationsAgeDemographics": list,
 
     "cumPeopleVaccinatedThirdDoseByPublishDate": int,
@@ -780,6 +786,12 @@ if ENVIRONMENT == "DEVELOPMENT":
         "cumVaccinationFirstDoseUptakeByVaccinationDatePercentage": float,
         "cumVaccinationCompleteCoverageByVaccinationDatePercentage": float,
         "newPeopleVaccinatedCompleteByVaccinationDate": int,
+
+        "cumPeopleVaccinatedAutumn22ByVaccinationDate50plus": int,
+        "cumVaccinationAutumn22UptakeByVaccinationDatePercentage50plus": float,
+        "newPeopleVaccinatedSpring23ByVaccinationDate75plus": int,
+        "cumPeopleVaccinatedSpring23ByVaccinationDate75plus": int,
+        "cumVaccinationSpring23UptakeByVaccinationDatePercentage75plus": float,
 
         "vaccinationsAgeDemographics": list,
 


### PR DESCRIPTION
Added:
cumPeopleVaccinatedAutumn22ByVaccinationDate50plus, cumVaccinationAutumn22UptakeByVaccinationDatePercentage50plus, newPeopleVaccinatedSpring23ByVaccinationDate75plus, cumPeopleVaccinatedSpring23ByVaccinationDate75plus, cumVaccinationSpring23UptakeByVaccinationDatePercentage75plus